### PR TITLE
Added Crew Capacity to Orbital Shipyards

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Konstruction/Parts/Konstruction_Orbital_Shipyard_250.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Konstruction/Parts/Konstruction_Orbital_Shipyard_250.cfg
@@ -35,6 +35,7 @@ PART
 	breakingTorque= 2000
 	maxTemp = 1200 // = 2900
 	bulkheadProfiles = size3
+	CrewCapacity = 1
 
 	MODULE
 	{

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Konstruction/Parts/Konstruction_Orbital_Shipyard_500.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Konstruction/Parts/Konstruction_Orbital_Shipyard_500.cfg
@@ -37,6 +37,7 @@ PART
 	breakingTorque= 2000
 	maxTemp = 1200 // = 2900
 	bulkheadProfiles = size3
+	CrewCapacity = 1
 
 	MODULE
 	{


### PR DESCRIPTION
Shipyards have no crew capacity, so you cannot put an engineer onboard to enable the Konstruction Bonus.