### PR TITLE
Add INTERNAL to part definitions of orbital shipyards

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Konstruction/Parts/Konstruction_Orbital_Shipyard_250.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Konstruction/Parts/Konstruction_Orbital_Shipyard_250.cfg
@@ -37,6 +37,10 @@ PART
 	bulkheadProfiles = size3
 	CrewCapacity = 1
 
+	INTERNAL
+	{
+		name = landerCabinInternals
+	}
 	MODULE
 	{
 		name = OrbitalKonstructorModule

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Konstruction/Parts/Konstruction_Orbital_Shipyard_500.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Konstruction/Parts/Konstruction_Orbital_Shipyard_500.cfg
@@ -39,6 +39,10 @@ PART
 	bulkheadProfiles = size3
 	CrewCapacity = 1
 
+	INTERNAL
+	{
+		name = landerCabinInternals
+	}
 	MODULE
 	{
 		name = OrbitalKonstructorModule


### PR DESCRIPTION
They were previously missing in the config files.