### PR TITLE
Fix attachment nodes becoming unusable in editor after undo

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Konstruction/Parts/PAL_Multimount.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Konstruction/Parts/PAL_Multimount.cfg
@@ -18,8 +18,8 @@ PART
 	node_stack_R3 = -.98975,     0,-.2,-1.0,0.0,0.0,1
 	node_stack_T2 = 0,    0,  -0.05,0.0,0.0,-1.0,1
 	node_stack_B2 = 0,    0, 0.05,0.0,0.0,1.0,1
-	node_stack_link_L = 1.0,0,0,1.0,0.0,0.0,1
-	node_stack_link_R = -1.0,0,0,-1.0,0.0,0.0,1
+	node_stack_linkL = 1.0,0,0,1.0,0.0,0.0,1
+	node_stack_linkR = -1.0,0,0,-1.0,0.0,0.0,1
 
 	node_stack_top = 0.0, 0.75, 0.0, 0.0, 1.0, 0.0, 1
 	node_stack_bottom = 0.0, -0.75, 0.0, 0.0, -1.0, 0.0, 1

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Konstruction/Parts/PAL_Truss.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Konstruction/Parts/PAL_Truss.cfg
@@ -25,8 +25,8 @@ PART
 	node_stack_B2 = 0,    0, 0.05,0.0,0.0,1.0,1
 	node_stack_B3 = 0, 1.25, 0.05,0.0,0.0,1.0,1
 
-	node_stack_link_L = 1.0,0,0,1.0,0.0,0.0,1
-	node_stack_link_R = -1.0,0,0,-1.0,0.0,0.0,1
+	node_stack_linkL = 1.0,0,0,1.0,0.0,0.0,1
+	node_stack_linkR = -1.0,0,0,-1.0,0.0,0.0,1
 
 	rescaleFactor = 1
 	node_stack_top = 0.0, 1.875, 0.0, 0.0, 1.0, 0.0, 1


### PR DESCRIPTION
fix bugreport UmbraSpaceIndustries/MKS#1571 for USI-Konstruction

Detailed description available in UmbraSpaceIndustries/MKS#1572.

I can't tell for sure, if this change makes problems for existing savegames, so I would appreciate it, if someone with more experience could verify, if this is a breaking change.